### PR TITLE
Add ability to snap-to-grid when adding a microphone point

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,7 @@ If you'd like to cite this project, please use this BibTex:
   year={2024}
 }
 ```
+
+## 🖱️ Snap-to-Grid Functionality
+
+You can now snap a microphone point to the nearest grid intersection by using `Shift + Click` when adding a microphone point. This allows for more precise placement of microphones on the grid.

--- a/src/components/MicMasterFlex.tsx
+++ b/src/components/MicMasterFlex.tsx
@@ -43,6 +43,15 @@ const MicMasterFlex = () => {
         y: -((point.y - (window.innerHeight / 2) - pan.y) / zoom),
     });
 
+    // Snap point to nearest grid intersection
+    const snapToGrid = (point: Point): Point => {
+        const step = gridSize / gridDivisions;
+        return {
+            x: Math.round(point.x / step) * step,
+            y: Math.round(point.y / step) * step,
+        };
+    };
+
     // Handle mouse down on the grid
     const handleMouseDown = (e: React.MouseEvent) => {
         if (!svgRef.current) return;
@@ -89,11 +98,11 @@ const MicMasterFlex = () => {
 
         if (Math.abs(point.x - dragStart!.x) < 5 && Math.abs(point.y - dragStart!.y) < 5) {
             if (mode === 'add') {
-                // Add new microphone at exact position
+                // Add new microphone at exact position or snapped to grid
                 const newMic: Microphone = {
                     id: `mic-${Date.now()}`,
-                    x: gridPoint.x,
-                    y: gridPoint.y,
+                    x: e.shiftKey ? snapToGrid(gridPoint).x : gridPoint.x,
+                    y: e.shiftKey ? snapToGrid(gridPoint).y : gridPoint.y,
                 };
                 setMicrophones([...microphones, newMic]);
             } else if (mode === 'delete' && hoveredMic) {


### PR DESCRIPTION
Fixes #15

Add snap-to-grid functionality when adding a microphone point using Shift + Click.

* **MicMasterFlex.tsx**
  - Add a function to snap points to the nearest grid intersection.
  - Update the `handleMouseUp` function to snap the microphone point to the grid when Shift + Click is detected.
  - Check for the Shift key being pressed during the click event and apply grid snapping logic.

* **README.md**
  - Add instructions for using Shift + Click to snap-to-grid when adding a microphone point.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nicolasperez19/mic-master-flex/issues/15?shareId=60405c2c-2de7-4352-9411-3bc18be8688c).